### PR TITLE
Upgraded: sbt and sbt-plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,67 +4,58 @@ ThisBuild / organization := "io.kevinlee"
 ThisBuild / version := ProjectVersion
 ThisBuild / scalaVersion := "2.13.3"
 
-ThisBuild / developers   := projectDevelopers
-ThisBuild / homepage     := projectHomePage
-ThisBuild / scmInfo      := projectScmInfo
+ThisBuild / developers := projectDevelopers
+ThisBuild / homepage := projectHomePage
+ThisBuild / scmInfo := projectScmInfo
 
 val projectBuildSourceEncoding = "UTF-8"
-val junitJupiterVersion = "5.6.2"
+val junitJupiterVersion        = "5.6.2"
 
 lazy val test0ster1 = (project in file("."))
-    .enablePlugins(DevOopsJavaPlugin)
-    .enablePlugins(DevOopsGitReleasePlugin)
-    .enablePlugins(JacocoCoverallsPlugin)
-    .settings(
-      name := "test0ster1"
-    , javacOptions := Seq(
-        "-source", javaVersion.value
-      , "-encoding", "UTF-8"
-      )
-    , javacOptions in (Compile, compile) ++= Seq(
-        "-target", javaVersion.value
-      , "-Xlint:unchecked"
-      , "-g"
-      , "-deprecation"
-      )
-    , javacOptions in (Compile, test) := (javacOptions in (Compile, compile)).value
-    , resolvers ++= Seq(
-        Resolver.jcenterRepo
-      )
-    , libraryDependencies ++= Seq(
-        "org.junit.jupiter" % "junit-jupiter" % junitJupiterVersion % Test
-      , "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test
-      , "org.assertj" % "assertj-core" % "3.17.2" % Test
-      , "org.mockito" % "mockito-core" % "3.5.10" % Test
-      )
-    , testOptions += Tests.Argument(TestFrameworks.JUnit, "-a")
+  .enablePlugins(DevOopsJavaPlugin)
+  .enablePlugins(DevOopsGitHubReleasePlugin)
+  .enablePlugins(JacocoCoverallsPlugin)
+  .settings(
+    name := "test0ster1",
+    javacOptions := List(
+      "-source",
+      javaVersion.value,
+      "-encoding",
+      "UTF-8"
+    ),
+    Compile / compile / javacOptions ++= List(
+      "-target",
+      javaVersion.value,
+      "-Xlint:unchecked",
+      "-g",
+      "-deprecation"
+    ),
+    Compile / test / javacOptions := (Compile / compile / javacOptions).value,
+    libraryDependencies ++= List(
+      "org.junit.jupiter" % "junit-jupiter"     % junitJupiterVersion              % Test,
+      "net.aichler"       % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
+      "org.assertj"       % "assertj-core"      % "3.17.2"                         % Test,
+      "org.mockito"       % "mockito-core"      % "3.5.10"                         % Test
+    ),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a")
 
-    /* Jacoco { */
-    , jacocoReportSettings := JacocoReportSettings(
-      "Jacoco Coverage Report"
-      , None
-      , JacocoThresholds()
-      , Seq(JacocoReportFormats.ScalaHTML, JacocoReportFormats.XML)
-      , "utf-8"
-    )
-    , jacocoCoverallsServiceName := "github-actions"
-    , jacocoCoverallsBranch := sys.env.get("CI_BRANCH")
-    , jacocoCoverallsPullRequest := sys.env.get("GITHUB_EVENT_NAME")
-    , jacocoCoverallsRepoToken := sys.env.get("COVERALLS_REPO_TOKEN")
-      /* } Jacoco */
-
-    , bintrayPackageLabels := Seq("maven", "java", "test", "java8")
-    , bintrayVcsUrl := Some("git@github.com:Kevin-Lee/test0ster1.git")
-    , bintrayRepository := "maven"
-
-    , publishMavenStyle := true
-    , publishArtifact in Test := false
-    , pomIncludeRepository := { _ => false }
-    , licenses += ("Apache-2.0", url("http://opensource.org/licenses/apache2.0"))
-    /* GitHub Release { */
-    , devOopsPackagedArtifacts := List(s"target/${name.value}*.jar")
+    /* Jacoco { */,
+    jacocoReportSettings := JacocoReportSettings(
+      "Jacoco Coverage Report",
+      None,
+      JacocoThresholds(),
+      List(JacocoReportFormats.ScalaHTML, JacocoReportFormats.XML),
+      "utf-8"
+    ),
+    jacocoCoverallsServiceName := "github-actions",
+    jacocoCoverallsBranch := sys.env.get("CI_BRANCH"),
+    jacocoCoverallsPullRequest := sys.env.get("GITHUB_EVENT_NAME"),
+    jacocoCoverallsRepoToken := sys.env.get("COVERALLS_REPO_TOKEN")
+    /* } Jacoco */,
+    publishMavenStyle := true,
+    Test / publishArtifact := false,
+    licenses := List("Apache-2.0" -> url("http://opensource.org/licenses/apache2.0"))
+    /* GitHub Release { */,
+    devOopsPackagedArtifacts := List(s"target/${name.value}*.jar")
     /* } GitHub Release */
-    )
-
-
-
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.2
+sbt.version = 1.5.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,10 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
+addSbtPlugin("com.geirsson"   % "sbt-ci-release"        % "1.5.7")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco"            % "3.3.0")
+addSbtPlugin("net.aichler"    % "sbt-jupiter-interface" % "0.9.1")
 
-addSbtPlugin("io.kevinlee" % "sbt-devoops" % "1.0.3")
-
-resolvers += Resolver.url("Kevin's bintray", url("https://dl.bintray.com/kevinlee/sbt-plugins"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.2.1")
-
-resolvers += Resolver.jcenterRepo
-
-addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.8.3")
+val sbtDevOopsVersion = "2.6.0"
+addSbtPlugin("io.kevinlee" % "sbt-devoops-java"      % sbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
+addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
Upgraded: sbt and sbt-plugins
- sbt `1.4.2` => `1.5.4`
- `sbt-bintray` => replaced by `sbt-ci-release`
- sbt-jacoco `3.2.1` => `3.3.0`
- sbt-jupiter-interface `0.8.3` => `0.9.1`
- sbt-devoops `1.0.3` => `2.6.0`